### PR TITLE
Fix missing script flag

### DIFF
--- a/src/uc_log/FTXUIGui.hpp
+++ b/src/uc_log/FTXUIGui.hpp
@@ -236,6 +236,7 @@ namespace uc_log { namespace FTXUIGui {
 
             auto const scriptPath = boost::process::environment::find_executable("script");
             if(!scriptPath.empty()) {
+                buildArguments.emplace_back("-e");
                 buildArguments.emplace_back("-q");
                 buildArguments.emplace_back("-c");
 


### PR DESCRIPTION
the -e flag was missing. Build status showed success even if it failed